### PR TITLE
memcp: bump to v0.3.0

### DIFF
--- a/Formula/memcp.rb
+++ b/Formula/memcp.rb
@@ -1,9 +1,9 @@
 class Memcp < Formula
   desc "Cross-session persistent memory MCP server for coding agents"
   homepage "https://github.com/helixerio/memcp"
-  url "https://github.com/helixerio/memcp/archive/refs/tags/v0.2.0.tar.gz",
+  url "https://github.com/helixerio/memcp/archive/refs/tags/v0.3.0.tar.gz",
     header: "Authorization: token #{ENV["HOMEBREW_GITHUB_API_TOKEN"] || `#{HOMEBREW_PREFIX}/bin/gh auth token 2>/dev/null`.chomp}"
-  sha256 "33887f52d1ccfaab49a220e19ab231b66a692d3bb058de20a9a5ef97db3cabc4"
+  sha256 "5c0137eaef307dfdce40d9ff7edf5e165a39c66ee595139db67e1e6aee0103e5"
   license "MIT"
 
   depends_on "go" => :build


### PR DESCRIPTION
## Summary
- Bumps memcp formula from v0.2.0 to v0.3.0
- Updates source tarball URL and SHA256 checksum