### PR TITLE
memcp: update 1.5.3

### DIFF
--- a/Formula/memcp.rb
+++ b/Formula/memcp.rb
@@ -1,16 +1,9 @@
 class Memcp < Formula
   desc "Cross-session persistent memory MCP server for coding agents"
   homepage "https://github.com/helixerio/memcp"
-  url "https://github.com/helixerio/memcp/archive/refs/tags/v1.5.2.tar.gz",
+  url "https://github.com/helixerio/memcp/archive/refs/tags/v1.5.3.tar.gz",
     header: "Authorization: token #{ENV["HOMEBREW_GITHUB_API_TOKEN"]}"
-  sha256 "769f924b0df93ac9708813e3e66f356526c9f4a3f42927ac13f68f3fc1c4cc8b"
-
-  bottle do
-    root_url "https://github.com/helixerio/homebrew-brews/releases/download/memcp-1.5.2"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6ffdc69323bc3454ce77ef7e637b52556834c601b15c507c847f58ce33588ac6"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "c15e861a6c027bd96733c2d8261e245e93ac7b89926f8676f7dec1b9eb02800c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1a38024a7460a88b1221c4ce62d0746899a3c8ca34c37a7d2ace2f569da0cc69"
-  end
+  sha256 "a8f740949f372f061c4de541cec192c473b9fb5b12a847b6275de4855ca5f1ab"
 
   depends_on "go" => :build
   depends_on "node" => :build


### PR DESCRIPTION
## Summary

Updates the `memcp` Homebrew formula from `v1.5.2` to `v1.5.3`.

## Changes

- Point `Formula/memcp.rb` at the `v1.5.3` source archive.
- Update the source SHA256 to the authenticated GitHub archive checksum.
- Remove the stale `1.5.2` bottle block so BrewTestBot can publish fresh bottles.

## Validation

- Verified the `v1.5.3` GitHub release exists and is not a draft or prerelease.
- Computed SHA256 from the exact formula archive URL with a GitHub auth token.
- `git diff --check`
- `/opt/homebrew/Library/Homebrew/vendor/portable-ruby/current/bin/ruby -c Formula/memcp.rb`

Note: `brew audit` by file path is rejected by this Homebrew version; no formula-specific audit result was produced locally.