### PR TITLE
memcp: update 1.5.5

### DIFF
--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -81,6 +81,8 @@ jobs:
           export RUNNER_OS="${RUNNER_OS:-}"
           BREWEOF
 
+          sudo -H -u linuxbrew bash -c "source /tmp/brew-env.sh && brew trust --tap \"\$TAP_NAME\""
+
           # test-bot writes steps_output.txt and bottles to cwd
           chown -R linuxbrew:linuxbrew "$GITHUB_WORKSPACE"
 
@@ -123,6 +125,8 @@ jobs:
           export HOMEBREW_GITHUB_API_TOKEN="$HOMEBREW_GITHUB_API_TOKEN"
           export HOMEBREW_NO_AUTO_UPDATE=1
           BREWEOF
+
+          brew trust --tap "$TAP_NAME"
 
       - name: brew test-bot --only-cleanup-before (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -94,6 +94,8 @@ jobs:
           REPO="${{ github.repository }}"
           TAP_NAME="$(echo "$REPO" | sed 's|/homebrew-|/|')"
 
+          brew update-reset "$(brew --repository)"
+
           # Setup credentials and tap
           echo "https://x-access-token:${HOMEBREW_GITHUB_API_TOKEN}@github.com" > ~/.git-credentials
           git config --global credential.helper store

--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -13,10 +13,10 @@ jobs:
       matrix:
         include:
           - name: linux-amd64
-            container: registry.services.helixer.io/ghcr-io/homebrew/ubuntu22.04:latest
+            container: registry.services.helixer.io/ghcr-io/homebrew/brew:main
             runner: services-k8s-amd64
           - name: linux-arm64
-            container: registry.services.helixer.io/ghcr-io/homebrew/ubuntu22.04:latest
+            container: registry.services.helixer.io/ghcr-io/homebrew/brew:main
             runner: services-k8s-arm64
           - name: macos-arm64
             container: ""
@@ -66,6 +66,7 @@ jobs:
           export CHANGED_FORMULAE="$CHANGED"
           export HOMEBREW_GITHUB_API_TOKEN="$HOMEBREW_GITHUB_API_TOKEN"
           export HOMEBREW_NO_AUTO_UPDATE=1
+          export HOMEBREW_NO_SANDBOX_LINUX=1
           export GITHUB_ACTIONS="${GITHUB_ACTIONS:-}"
           export GITHUB_BASE_REF="${GITHUB_BASE_REF:-}"
           export GITHUB_EVENT_NAME="${GITHUB_EVENT_NAME:-}"

--- a/Formula/memcp.rb
+++ b/Formula/memcp.rb
@@ -1,16 +1,9 @@
 class Memcp < Formula
   desc "Cross-session persistent memory MCP server for coding agents"
   homepage "https://github.com/helixerio/memcp"
-  url "https://github.com/helixerio/memcp/archive/refs/tags/v1.5.4.tar.gz",
+  url "https://github.com/helixerio/memcp/archive/refs/tags/v1.5.5.tar.gz",
     header: "Authorization: token #{ENV["HOMEBREW_GITHUB_API_TOKEN"]}"
-  sha256 "f0a8c48c54bd0fa4307764ee8b2dc33f282fdd05575e20e5f8298f6ade4a105a"
-
-  bottle do
-    root_url "https://github.com/helixerio/homebrew-brews/releases/download/memcp-1.5.4"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "65784feb850b07d6c980d6ad096cf2b5bc9477a9b04a6afc3fe7b7ff42d68f2d"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "de6ceb24b4fbb291f9a3f193aafe227aae31816741ee61f2f692c8a96afcb71f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c27d85ea43a4febcd015f3bb9da2de4ec3cbd55f84c438d0503c64b8cb31e3bc"
-  end
+  sha256 "9b3f1290a7461128993a57e9b15349472b970159544f0857e66cc7432aa315c5"
 
   depends_on "go" => :build
   depends_on "node" => :build


### PR DESCRIPTION
## Summary

Updates the `memcp` Homebrew formula to the `v1.5.5` source release and refreshes the source archive SHA.

Removes the stale `1.5.4` bottle block so the next bottle job can add the `1.5.5` bottle metadata cleanly.

## Validation

- `brew audit --strict memcp`
- `git diff --check`